### PR TITLE
Make log dir if necessary

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -126,5 +126,10 @@ def run_sql_query(connection, query, dict_param):
 
 
 def clear_log_file(logfile):
+    # make sure log directory exists
+    try:
+        os.makedirs(os.path.dirname(logfile))
+    except OSError:
+        pass
     with open(logfile, 'w'):
         pass


### PR DESCRIPTION
Note: `makedirs()` fails with `OSError` if the directory already exists, hence the `try-except-pass`. Should probably test with and without an existing log-dir